### PR TITLE
Refactor details API to POST and return minimal fields

### DIFF
--- a/app/controllers/api/v1/flights_controller.rb
+++ b/app/controllers/api/v1/flights_controller.rb
@@ -109,6 +109,21 @@ module Api
             class_type: class_type,
             available_seats: available_seats
           )
+          {
+            airlines: flight[:airlines],
+            flight_number: flight[:flight_number],
+            source: flight[:source],
+            destination: flight[:destination],
+            departure_date: flight[:departure_date],
+            departure_time: flight[:departure_time],
+            arrival_date: flight[:arrival_date],
+            arrival_time: flight[:arrival_time],
+            class_type: class_type,
+            available_seats: available_seats,
+            price: base_price,
+            total_cost: total_fare,
+            passengers: passengers
+          }
         end
 
         render json: { data: results, message: "Flights matching your criteria" }, status: :ok

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,3 @@
 class ApplicationController < ActionController::API
+    wrap_parameters format: []
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
       }
       resources :flights, only: [ :index ] do
         collection do
-          get :details
+          post :details
           get :search
           patch :update_seat_count
         end

--- a/spec/requests/flights_spec.rb
+++ b/spec/requests/flights_spec.rb
@@ -98,9 +98,9 @@ RSpec.describe "Api::V1::FlightsController", type: :request do
     end
   end
 
-  describe "Tests related to the route GET /api/v1/flights/details" do
+  describe "Tests related to the route POST /api/v1/flights/details" do
     it "should returns matching flights when valid params are provided" do
-      get "/api/v1/flights/details", params: {
+      post "/api/v1/flights/details", params: {
         source: "Delhi",
         destination: "Mumbai",
         departure_date: "2025-07-20",
@@ -113,7 +113,7 @@ RSpec.describe "Api::V1::FlightsController", type: :request do
     end
 
     it "should returns error when source and destination are the same" do
-      get "/api/v1/flights/details", params: {
+      post "/api/v1/flights/details", params: {
         source: "Delhi",
         destination: "Delhi"
       }
@@ -123,7 +123,7 @@ RSpec.describe "Api::V1::FlightsController", type: :request do
     end
 
     it "should returns error when no flights found" do
-      get "/api/v1/flights/details", params: {
+      post "/api/v1/flights/details", params: {
         source: "Warangal",
         destination: "Karimnagar"
       }
@@ -133,14 +133,14 @@ RSpec.describe "Api::V1::FlightsController", type: :request do
     end
 
     it "should returns error when params are missing" do
-      get "/api/v1/flights/details", params: { destination: "Mumbai" }
+      post "/api/v1/flights/details", params: { destination: "Mumbai" }
       expect(response).to have_http_status(:bad_request)
       body = JSON.parse(response.body)
       expect(body["error"]).to eq("Source and destination are required")
     end
 
     it "should returns error if no flights available with the given criteria" do
-      get "/api/v1/flights/details", params: {
+      post "/api/v1/flights/details", params: {
         source: "Delhi",
         destination: "Mumbai",
         departure_date: "2025-07-20",
@@ -153,7 +153,7 @@ RSpec.describe "Api::V1::FlightsController", type: :request do
     end
 
     it "should calculates price using first class base price when class_type is 'first class'" do
-      get "/api/v1/flights/details", params: {
+      post "/api/v1/flights/details", params: {
         source: "Delhi",
         destination: "Mumbai",
         departure_date: "2025-07-20",
@@ -167,7 +167,7 @@ RSpec.describe "Api::V1::FlightsController", type: :request do
     end
 
     it "should calculates price using second class base price when class_type is 'second class'" do
-      get "/api/v1/flights/details", params: {
+      post "/api/v1/flights/details", params: {
         source: "Delhi",
         destination: "Mumbai",
         departure_date: "2025-07-20",


### PR DESCRIPTION
## 📌 What does this PR do?

- Switched `details` API from **GET** to **POST** for better request structure.
- Now returns **only essential flight details** to the frontend.

## 📌 Changes Made

- Updated `routes.rb` to use **POST** for `details`.
- Modified controller to:
  - Accept POST payload cleanly.
  - Return only needed fields:
    - `airlines`
    - `arrival_date`
    - `arrival_time`
    - `available_seats`
    - `class_type`
    - `departure_date`
    - `departure_time`
    - `destination`
    - `flight_number`
    - `passengers`
    - `price`
    - `source`
    - `total_cost

## ✅ Validation

- Verified with **frontend integration**.
- Confirmed correct POST payload acceptance.
- Checked that only necessary fields are returned in the response.

### Thank you!
